### PR TITLE
Instanciate Swift_Message with a new

### DIFF
--- a/Channel/SwiftmailerChannel.php
+++ b/Channel/SwiftmailerChannel.php
@@ -81,7 +81,7 @@ class SwiftmailerChannel implements ChannelInterface
      */
     public function handle(Delivery $delivery)
     {
-        $mail = Swift_Message::newInstance();
+        $mail = new Swift_Message();
 
         $this->configurator->configure($mail, $delivery);
 


### PR DESCRIPTION
newInstance static method was removed in swiftmailer 6