### PR TITLE
 Switched doctrine recipient id to a string

### DIFF
--- a/Entity/Notification.php
+++ b/Entity/Notification.php
@@ -44,7 +44,7 @@ class Notification
     private $recipientClass;
 
     /**
-     * @var int
+     * @var string
      */
     private $recipientId;
 
@@ -110,7 +110,7 @@ class Notification
     }
 
     /**
-     * @return int
+     * @return string
      */
     public function getRecipientId()
     {

--- a/Recipient/DoctrineRecipientInterface.php
+++ b/Recipient/DoctrineRecipientInterface.php
@@ -8,7 +8,7 @@ namespace Yokai\MessengerBundle\Recipient;
 interface DoctrineRecipientInterface
 {
     /**
-     * @return int
+     * @return string
      */
     public function getId();
 }

--- a/Resources/config/model/Notification.orm.xml
+++ b/Resources/config/model/Notification.orm.xml
@@ -21,7 +21,7 @@
         <field name="body"           column="body"            type="text"     nullable="false"/>
         <field name="recordedAt"     column="recorded_at"     type="datetime" nullable="false"/>
         <field name="recipientClass" column="recipient_class" type="string"   nullable="false" length="255"/>
-        <field name="recipientId"    column="recipient_id"    type="integer"  nullable="false"/>
+        <field name="recipientId"    column="recipient_id"    type="string"   nullable="false" length="255"/>
         <field name="deliveredAt"    column="delivered_at"    type="datetime" nullable="true"/>
 
         <one-to-many

--- a/Tests/Channel/DoctrineChannelTest.php
+++ b/Tests/Channel/DoctrineChannelTest.php
@@ -64,14 +64,14 @@ class DoctrineChannelTest extends \PHPUnit_Framework_TestCase
 
     public function testIsCreatingNotificationEntity()
     {
-        $recipient = new DoctrineRecipient(1);
+        $recipient = new DoctrineRecipient('1');
 
         $notificationProphecy = Argument::allOf(
             Argument::type(Notification::class),
             Argument::which('getSubject', 'subject'),
             Argument::which('getBody', 'body'),
             Argument::which('getRecipientClass', DoctrineRecipient::class),
-            Argument::which('getRecipientId', 1)
+            Argument::which('getRecipientId', '1')
         );
 
         $this->manager->persist($notificationProphecy)
@@ -112,7 +112,7 @@ class DoctrineChannelTest extends \PHPUnit_Framework_TestCase
                 false,
             ],
             [
-                new DoctrineRecipient(1),
+                new DoctrineRecipient('1'),
                 true,
             ],
             [

--- a/Tests/Channel/MobileChannelTest.php
+++ b/Tests/Channel/MobileChannelTest.php
@@ -171,7 +171,7 @@ class MobileChannelTest extends \PHPUnit_Framework_TestCase
                 false,
             ],
             [
-                new DoctrineRecipient(1),
+                new DoctrineRecipient('1'),
                 false,
             ],
             [

--- a/Tests/Channel/SwiftmailerChannelTest.php
+++ b/Tests/Channel/SwiftmailerChannelTest.php
@@ -242,7 +242,7 @@ class SwiftmailerChannelTest extends \PHPUnit_Framework_TestCase
     {
         return [
             [
-                new DoctrineRecipient(1),
+                new DoctrineRecipient('1'),
                 false,
             ],
             [

--- a/Tests/Channel/TwilioChannelTest.php
+++ b/Tests/Channel/TwilioChannelTest.php
@@ -181,7 +181,7 @@ class TwilioChannelTest extends \PHPUnit_Framework_TestCase
     {
         return [
             [
-                new DoctrineRecipient(1),
+                new DoctrineRecipient('1'),
                 false,
             ],
             [

--- a/Tests/Entity/NotificationTest.php
+++ b/Tests/Entity/NotificationTest.php
@@ -15,14 +15,14 @@ class NotificationTest extends \PHPUnit_Framework_TestCase
         $notification = new Notification(
             'subject',
             'body',
-            new DoctrineRecipient(1)
+            new DoctrineRecipient('1')
         );
 
         $this->assertSame(null, $notification->getId());
         $this->assertSame('subject', $notification->getSubject());
         $this->assertSame('body', $notification->getBody());
         $this->assertSame(DoctrineRecipient::class, $notification->getRecipientClass());
-        $this->assertSame(1, $notification->getRecipientId());
+        $this->assertSame('1', $notification->getRecipientId());
         $this->assertInstanceOf(\DateTime::class, $notification->getRecordedAt());
 
         $this->assertNull(null, $notification->getDeliveredAt());
@@ -37,7 +37,7 @@ class NotificationTest extends \PHPUnit_Framework_TestCase
         $notification = new Notification(
             'subject',
             'body',
-            new DoctrineRecipient(1)
+            new DoctrineRecipient('1')
         );
 
         $notification->setDelivered();


### PR DESCRIPTION
to allow more integration with other identifier types

Fixes Issue #29
