### PR TITLE
Replace usage of symfony/templating with twig/twig

### DIFF
--- a/Helper/ContentBuilder.php
+++ b/Helper/ContentBuilder.php
@@ -3,9 +3,8 @@
 namespace Yokai\MessengerBundle\Helper;
 
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Templating\EngineInterface;
 use Symfony\Component\Translation\TranslatorInterface;
-use Yokai\MessengerBundle\Channel\ChannelInterface;
+use Twig\Environment;
 use Yokai\MessengerBundle\Exception\BadMethodCallException;
 
 /**
@@ -14,9 +13,9 @@ use Yokai\MessengerBundle\Exception\BadMethodCallException;
 class ContentBuilder
 {
     /**
-     * @var EngineInterface
+     * @var Environment
      */
-    private $templating;
+    private $twig;
 
     /**
      * @var TranslatorInterface
@@ -34,13 +33,13 @@ class ContentBuilder
     private $options;
 
     /**
-     * @param EngineInterface     $templating
+     * @param Environment         $twig
      * @param TranslatorInterface $translator
      * @param array               $defaults
      */
-    public function __construct(EngineInterface $templating, TranslatorInterface $translator, array $defaults)
+    public function __construct(Environment $twig, TranslatorInterface $translator, array $defaults)
     {
-        $this->templating = $templating;
+        $this->twig = $twig;
         $this->translator = $translator;
         $this->defaults = $defaults;
     }
@@ -117,7 +116,7 @@ class ContentBuilder
             );
         }
 
-        return $this->templating->render(
+        return $this->twig->render(
             strtr(
                 $this->options['template'],
                 array_intersect_key($parameters, array_flip($this->options['template_parameters']))

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -19,7 +19,7 @@
         <service id="yokai_messenger.content_builder"
                  class="Yokai\MessengerBundle\Helper\ContentBuilder"
                  public="false">
-            <argument type="service" id="templating"/>
+            <argument type="service" id="twig"/>
             <argument type="service" id="translator"/>
             <argument>%yokai_messenger.content_builder_defaults%</argument>
         </service>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -19,9 +19,10 @@
         <service id="yokai_messenger.content_builder"
                  class="Yokai\MessengerBundle\Helper\ContentBuilder"
                  public="false">
-            <argument type="service" id="twig"/>
             <argument type="service" id="translator"/>
             <argument>%yokai_messenger.content_builder_defaults%</argument>
+            <argument type="service" id="templating" on-invalid="ignore"/>
+            <argument type="service" id="twig" on-invalid="ignore"/>
         </service>
 
         <service id="yokai_messenger.notification_repository"

--- a/Resources/docs/usage.md
+++ b/Resources/docs/usage.md
@@ -67,7 +67,7 @@ options available are :
 
 ### Building body
 
-The body is built using [Symfony's templating component](http://symfony.com/doc/current/components/templating.html), 
+The body is built using [Twig](https://twig.symfony.com/), 
 options available are :
 
 - `template`: a template name (or pattern)

--- a/Tests/DependencyInjection/DependencyInjectionTest.php
+++ b/Tests/DependencyInjection/DependencyInjectionTest.php
@@ -11,8 +11,8 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\Templating\EngineInterface;
 use Symfony\Component\Translation\TranslatorInterface;
+use Twig\Environment;
 use Yokai\MessengerBundle\Message;
 use Yokai\MessengerBundle\Tests\Fixtures\Channel\DummyChannel;
 use Yokai\MessengerBundle\Tests\Fixtures\Channel\InvalidChannel;
@@ -44,7 +44,7 @@ class DependencyInjectionTest extends \PHPUnit_Framework_TestCase
 
         $this->container->setParameter('kernel.debug', true);
         $this->container->setParameter('kernel.bundles', $bundles);
-        $this->container->set('templating', $this->prophesize(EngineInterface::class)->reveal());
+        $this->container->set('twig', $this->prophesize(Environment::class)->reveal());
         $this->container->set('translator', $this->prophesize(TranslatorInterface::class)->reveal());
         $this->container->set('logger', $this->prophesize(LoggerInterface::class)->reveal());
         $this->container->set('mailer', $this->prophesize(\Swift_Mailer::class)->reveal());

--- a/Tests/Helper/ContentBuilderTest.php
+++ b/Tests/Helper/ContentBuilderTest.php
@@ -3,7 +3,6 @@
 namespace Yokai\MessengerBundle\Tests\Helper;
 
 use Prophecy\Prophecy\ObjectProphecy;
-use Symfony\Component\Templating\EngineInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 use Twig\Environment;
 use Yokai\MessengerBundle\Helper\ContentBuilder;

--- a/Tests/Helper/ContentBuilderTest.php
+++ b/Tests/Helper/ContentBuilderTest.php
@@ -5,6 +5,7 @@ namespace Yokai\MessengerBundle\Tests\Helper;
 use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Component\Templating\EngineInterface;
 use Symfony\Component\Translation\TranslatorInterface;
+use Twig\Environment;
 use Yokai\MessengerBundle\Helper\ContentBuilder;
 
 /**
@@ -15,7 +16,7 @@ class ContentBuilderTest extends \PHPUnit_Framework_TestCase
     /**
      * @var ObjectProphecy
      */
-    private $templating;
+    private $twig;
 
     /**
      * @var ObjectProphecy
@@ -24,14 +25,14 @@ class ContentBuilderTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->templating = $this->prophesize(EngineInterface::class);
+        $this->twig = $this->prophesize(Environment::class);
         $this->translator = $this->prophesize(TranslatorInterface::class);
     }
 
     protected function tearDown()
     {
         unset(
-            $this->templating,
+            $this->twig,
             $this->translator
         );
     }
@@ -39,7 +40,7 @@ class ContentBuilderTest extends \PHPUnit_Framework_TestCase
     protected function createHelper(array $defaults)
     {
         return new ContentBuilder(
-            $this->templating->reveal(),
+            $this->twig->reveal(),
             $this->translator->reveal(),
             $defaults
         );
@@ -124,7 +125,7 @@ class ContentBuilderTest extends \PHPUnit_Framework_TestCase
 
         $helper->configure($options);
 
-        $this->templating->render($expectedTemplate, $expectedParameters)
+        $this->twig->render($expectedTemplate, $expectedParameters)
             ->shouldBeCalled()
             ->willReturn('test ok');
 

--- a/Tests/Helper/ContentBuilderTest.php
+++ b/Tests/Helper/ContentBuilderTest.php
@@ -39,9 +39,10 @@ class ContentBuilderTest extends \PHPUnit_Framework_TestCase
     protected function createHelper(array $defaults)
     {
         return new ContentBuilder(
-            $this->twig->reveal(),
             $this->translator->reveal(),
-            $defaults
+            $defaults,
+            null,
+            $this->twig->reveal()
         );
     }
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "php": ">=5.6",
         "symfony/framework-bundle": "~2.8|~3.0|~4.0",
         "symfony/translation": "~2.8|~3.0|~4.0",
-        "twig/twig": "~2.0",
+        "twig/twig": "~1.34|~2.0",
         "yokai/dependency-injection": "~1.0"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     "require": {
         "php": ">=5.6",
         "symfony/framework-bundle": "~2.8|~3.0|~4.0",
-        "symfony/templating": "~2.8|~3.0|~4.0",
         "symfony/translation": "~2.8|~3.0|~4.0",
+        "twig/twig": "~2.0",
         "yokai/dependency-injection": "~1.0"
     },
     "suggest": {


### PR DESCRIPTION
The `symfony/templating` component is not part of standard anymore, remove it in favor of direct dependency to `twig/twig`