### PR TITLE
Renamed recipient to be less coupled to their channel and deprecated the old ones

### DIFF
--- a/Channel/DoctrineChannel.php
+++ b/Channel/DoctrineChannel.php
@@ -33,11 +33,7 @@ class DoctrineChannel implements ChannelInterface
      */
     public function supports($recipient)
     {
-        if (is_object($recipient) && $recipient instanceof IdentifierRecipientInterface) {
-            return true;
-        }
-
-        return false;
+        return $recipient instanceof IdentifierRecipientInterface;
     }
 
     /**

--- a/Channel/DoctrineChannel.php
+++ b/Channel/DoctrineChannel.php
@@ -8,7 +8,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 use Yokai\MessengerBundle\Delivery;
 use Yokai\MessengerBundle\Entity\Notification;
 use Yokai\MessengerBundle\Entity\NotificationAttachment;
-use Yokai\MessengerBundle\Recipient\DoctrineRecipientInterface;
+use Yokai\MessengerBundle\Recipient\IdentifierRecipientInterface;
 
 /**
  * @author Yann Eugoné <eugone.yann@gmail.com>
@@ -33,7 +33,7 @@ class DoctrineChannel implements ChannelInterface
      */
     public function supports($recipient)
     {
-        if (is_object($recipient) && $recipient instanceof DoctrineRecipientInterface) {
+        if (is_object($recipient) && $recipient instanceof IdentifierRecipientInterface) {
             return true;
         }
 

--- a/Channel/MobileChannel.php
+++ b/Channel/MobileChannel.php
@@ -10,7 +10,7 @@ use Sly\NotificationPusher\Model\Push;
 use Sly\NotificationPusher\PushManager;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Yokai\MessengerBundle\Delivery;
-use Yokai\MessengerBundle\Recipient\MobileRecipientInterface;
+use Yokai\MessengerBundle\Recipient\NotificationRecipientInterface;
 
 /**
  * @author Yann Eugoné <eugone.yann@gmail.com>
@@ -42,7 +42,7 @@ class MobileChannel implements ChannelInterface
      */
     public function supports($recipient)
     {
-        return $recipient instanceof MobileRecipientInterface;
+        return $recipient instanceof NotificationRecipientInterface;
     }
 
     /**
@@ -60,7 +60,7 @@ class MobileChannel implements ChannelInterface
      */
     public function handle(Delivery $delivery)
     {
-        /** @var $recipient MobileRecipientInterface */
+        /** @var $recipient NotificationRecipientInterface */
         $recipient = $delivery->getRecipient();
 
         $options = $delivery->getOptions();

--- a/Channel/Swiftmailer/Configurator/DefaultMessageConfigurator.php
+++ b/Channel/Swiftmailer/Configurator/DefaultMessageConfigurator.php
@@ -5,7 +5,7 @@ namespace Yokai\MessengerBundle\Channel\Swiftmailer\Configurator;
 use Swift_Attachment;
 use Swift_Message;
 use Yokai\MessengerBundle\Delivery;
-use Yokai\MessengerBundle\Recipient\SwiftmailerRecipientInterface;
+use Yokai\MessengerBundle\Recipient\EmailRecipientInterface;
 
 /**
  * @author Yann Eugoné <eugone.yann@gmail.com>
@@ -24,7 +24,7 @@ class DefaultMessageConfigurator implements SwiftMessageConfiguratorInterface
         $message
             ->setSubject($delivery->getSubject())
             ->setFrom($options['from'])
-            ->setTo($recipient instanceof SwiftmailerRecipientInterface ? $recipient->getEmail() : $recipient)
+            ->setTo($recipient instanceof EmailRecipientInterface ? $recipient->getEmail() : $recipient)
             ->setBody($delivery->getBody(), 'text/html')
         ;
 

--- a/Channel/SwiftmailerChannel.php
+++ b/Channel/SwiftmailerChannel.php
@@ -54,7 +54,7 @@ class SwiftmailerChannel implements ChannelInterface
         }
 
         if (is_string($recipient)) {
-            return filter_var($recipient, FILTER_VALIDATE_EMAIL);
+            return false !== filter_var($recipient, FILTER_VALIDATE_EMAIL);
         }
 
         return false;

--- a/Channel/SwiftmailerChannel.php
+++ b/Channel/SwiftmailerChannel.php
@@ -7,7 +7,7 @@ use Swift_Message;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Yokai\MessengerBundle\Channel\Swiftmailer\Configurator\SwiftMessageConfiguratorInterface;
 use Yokai\MessengerBundle\Delivery;
-use Yokai\MessengerBundle\Recipient\SwiftmailerRecipientInterface;
+use Yokai\MessengerBundle\Recipient\EmailRecipientInterface;
 
 /**
  * @author Yann Eugoné <eugone.yann@gmail.com>
@@ -49,7 +49,7 @@ class SwiftmailerChannel implements ChannelInterface
      */
     public function supports($recipient)
     {
-        if (is_object($recipient) && $recipient instanceof SwiftmailerRecipientInterface) {
+        if (is_object($recipient) && $recipient instanceof EmailRecipientInterface) {
             return true;
         }
 

--- a/Channel/SwiftmailerChannel.php
+++ b/Channel/SwiftmailerChannel.php
@@ -49,12 +49,12 @@ class SwiftmailerChannel implements ChannelInterface
      */
     public function supports($recipient)
     {
-        if (is_object($recipient) && $recipient instanceof EmailRecipientInterface) {
-            return true;
+        if (is_object($recipient)) {
+            return $recipient instanceof EmailRecipientInterface;
         }
 
-        if (is_string($recipient) && filter_var($recipient, FILTER_VALIDATE_EMAIL)) {
-            return true;
+        if (is_string($recipient)) {
+            return filter_var($recipient, FILTER_VALIDATE_EMAIL);
         }
 
         return false;

--- a/Channel/TwilioChannel.php
+++ b/Channel/TwilioChannel.php
@@ -5,7 +5,7 @@ namespace Yokai\MessengerBundle\Channel;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Yokai\MessengerBundle\Channel\Twilio\Factory\ClientFactoryInterface;
 use Yokai\MessengerBundle\Delivery;
-use Yokai\MessengerBundle\Recipient\TwilioRecipientInterface;
+use Yokai\MessengerBundle\Recipient\PhoneRecipientInterface;
 
 /**
  * @author Matthieu Crinquand <matthieu.crinquand@gmail.com>
@@ -36,7 +36,7 @@ class TwilioChannel implements ChannelInterface
 
     public function supports($recipient)
     {
-        if (is_object($recipient) && $recipient instanceof TwilioRecipientInterface) {
+        if (is_object($recipient) && $recipient instanceof PhoneRecipientInterface) {
             return true;
         }
 
@@ -69,7 +69,7 @@ class TwilioChannel implements ChannelInterface
 
         $client = $this->twilioClientFactory->createClient($options['api_id'], $options['api_token']);
 
-        $phone = $recipient instanceof TwilioRecipientInterface ? $recipient->getPhone() : $recipient;
+        $phone = $recipient instanceof PhoneRecipientInterface ? $recipient->getPhone() : $recipient;
 
         $client->messages->create($phone, [
             'from' => $options['from'],

--- a/Channel/TwilioChannel.php
+++ b/Channel/TwilioChannel.php
@@ -36,8 +36,8 @@ class TwilioChannel implements ChannelInterface
 
     public function supports($recipient)
     {
-        if (is_object($recipient) && $recipient instanceof PhoneRecipientInterface) {
-            return true;
+        if (is_object($recipient)) {
+            return $recipient instanceof PhoneRecipientInterface;
         }
 
         if (is_string($recipient)) {

--- a/Entity/Notification.php
+++ b/Entity/Notification.php
@@ -6,7 +6,7 @@ use DateTime;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Util\ClassUtils;
-use Yokai\MessengerBundle\Recipient\DoctrineRecipientInterface;
+use Yokai\MessengerBundle\Recipient\IdentifierRecipientInterface;
 
 /**
  * @author Yann Eugoné <eugone.yann@gmail.com>
@@ -54,11 +54,11 @@ class Notification
     private $deliveredAt;
 
     /**
-     * @param string                     $subject
-     * @param string                     $body
-     * @param DoctrineRecipientInterface $recipient
+     * @param string                       $subject
+     * @param string                       $body
+     * @param IdentifierRecipientInterface $recipient
      */
-    public function __construct($subject, $body, DoctrineRecipientInterface $recipient)
+    public function __construct($subject, $body, IdentifierRecipientInterface $recipient)
     {
         $this->subject = $subject;
         $this->body = $body;

--- a/Entity/Repository/NotificationRepository.php
+++ b/Entity/Repository/NotificationRepository.php
@@ -6,7 +6,7 @@ use Doctrine\Common\Util\ClassUtils;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\QueryBuilder;
 use Yokai\MessengerBundle\Entity\Notification;
-use Yokai\MessengerBundle\Recipient\DoctrineRecipientInterface;
+use Yokai\MessengerBundle\Recipient\IdentifierRecipientInterface;
 
 /**
  * @author Yann Eugoné <eugone.yann@gmail.com>
@@ -24,12 +24,12 @@ class NotificationRepository extends EntityRepository
     }
 
     /**
-     * @param QueryBuilder               $builder
-     * @param DoctrineRecipientInterface $recipient
+     * @param QueryBuilder                 $builder
+     * @param IdentifierRecipientInterface $recipient
      *
      * @return QueryBuilder
      */
-    public function addRecipientConditions(QueryBuilder $builder, DoctrineRecipientInterface $recipient)
+    public function addRecipientConditions(QueryBuilder $builder, IdentifierRecipientInterface $recipient)
     {
         $alias = $builder->getRootAliases()[0];
         $builder
@@ -47,11 +47,11 @@ class NotificationRepository extends EntityRepository
     }
 
     /**
-     * @param DoctrineRecipientInterface  $recipient
+     * @param IdentifierRecipientInterface  $recipient
      *
      * @return int
      */
-    public function countUndeliveredRecipientNotification(DoctrineRecipientInterface $recipient)
+    public function countUndeliveredRecipientNotification(IdentifierRecipientInterface $recipient)
     {
         $builder = $this->createQueryBuilder('notification');
         $builder
@@ -64,11 +64,11 @@ class NotificationRepository extends EntityRepository
     }
 
     /**
-     * @param DoctrineRecipientInterface $recipient
+     * @param IdentifierRecipientInterface $recipient
      *
      * @return Notification[]
      */
-    public function findUndeliveredRecipientNotification(DoctrineRecipientInterface $recipient)
+    public function findUndeliveredRecipientNotification(IdentifierRecipientInterface $recipient)
     {
         $builder = $this->createQueryBuilder('notification');
 
@@ -80,11 +80,11 @@ class NotificationRepository extends EntityRepository
     }
 
     /**
-     * @param DoctrineRecipientInterface $recipient
+     * @param IdentifierRecipientInterface $recipient
      *
      * @return Notification[]
      */
-    public function findAllForRecipient(DoctrineRecipientInterface $recipient)
+    public function findAllForRecipient(IdentifierRecipientInterface $recipient)
     {
         $builder = $this->createQueryBuilder('notification');
 

--- a/Recipient/DoctrineRecipientInterface.php
+++ b/Recipient/DoctrineRecipientInterface.php
@@ -4,11 +4,9 @@ namespace Yokai\MessengerBundle\Recipient;
 
 /**
  * @author Yann Eugoné <eugone.yann@gmail.com>
+ *
+ * @deprecated since 1.5, use \Yokai\MessengerBundle\Recipient\IdentifierRecipientInterface instead
  */
-interface DoctrineRecipientInterface
+interface DoctrineRecipientInterface extends IdentifierRecipientInterface
 {
-    /**
-     * @return string
-     */
-    public function getId();
 }

--- a/Recipient/EmailRecipientInterface.php
+++ b/Recipient/EmailRecipientInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Yokai\MessengerBundle\Recipient;
+
+/**
+ * @author Yann Eugoné <eugone.yann@gmail.com>
+ */
+interface EmailRecipientInterface
+{
+    /**
+     * @return string
+     */
+    public function getEmail();
+}

--- a/Recipient/IdentifierRecipientInterface.php
+++ b/Recipient/IdentifierRecipientInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Yokai\MessengerBundle\Recipient;
+
+/**
+ * @author Yann Eugoné <eugone.yann@gmail.com>
+ */
+interface IdentifierRecipientInterface
+{
+    /**
+     * @return string
+     */
+    public function getId();
+}

--- a/Recipient/MobileRecipientInterface.php
+++ b/Recipient/MobileRecipientInterface.php
@@ -4,11 +4,9 @@ namespace Yokai\MessengerBundle\Recipient;
 
 /**
  * @author Yann Eugoné <eugone.yann@gmail.com>
+ *
+ * @deprecated since 1.5, use \Yokai\MessengerBundle\Recipient\NotificationRecipientInterface instead
  */
-interface MobileRecipientInterface
+interface MobileRecipientInterface extends NotificationRecipientInterface
 {
-    /**
-     * @return array
-     */
-    public function getDevicesTokens();
 }

--- a/Recipient/NotificationRecipientInterface.php
+++ b/Recipient/NotificationRecipientInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Yokai\MessengerBundle\Recipient;
+
+/**
+ * @author Yann Eugoné <eugone.yann@gmail.com>
+ */
+interface NotificationRecipientInterface
+{
+    /**
+     * @return array
+     */
+    public function getDevicesTokens();
+}

--- a/Recipient/PhoneRecipientInterface.php
+++ b/Recipient/PhoneRecipientInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Yokai\MessengerBundle\Recipient;
+
+/**
+ * @author Matthieu Crinquand <matthieu.crinquand@gmail.com>
+ */
+interface PhoneRecipientInterface
+{
+    /**
+     * @return string
+     */
+    public function getPhone();
+}

--- a/Recipient/SwiftmailerRecipientInterface.php
+++ b/Recipient/SwiftmailerRecipientInterface.php
@@ -4,11 +4,9 @@ namespace Yokai\MessengerBundle\Recipient;
 
 /**
  * @author Yann Eugoné <eugone.yann@gmail.com>
+ *
+ * @deprecated since 1.5, use \Yokai\MessengerBundle\Recipient\EmailRecipientInterface instead
  */
-interface SwiftmailerRecipientInterface
+interface SwiftmailerRecipientInterface extends EmailRecipientInterface
 {
-    /**
-     * @return string
-     */
-    public function getEmail();
 }

--- a/Recipient/TwilioRecipientInterface.php
+++ b/Recipient/TwilioRecipientInterface.php
@@ -4,11 +4,9 @@ namespace Yokai\MessengerBundle\Recipient;
 
 /**
  * @author Matthieu Crinquand <matthieu.crinquand@gmail.com>
+ *
+ * @deprecated since 1.5, use \Yokai\MessengerBundle\Recipient\PhoneRecipientInterface instead
  */
-interface TwilioRecipientInterface
+interface TwilioRecipientInterface extends PhoneRecipientInterface
 {
-    /**
-     * @return string
-     */
-    public function getPhone();
 }

--- a/Tests/Channel/DoctrineChannelTest.php
+++ b/Tests/Channel/DoctrineChannelTest.php
@@ -9,10 +9,10 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 use Yokai\MessengerBundle\Channel\DoctrineChannel;
 use Yokai\MessengerBundle\Delivery;
 use Yokai\MessengerBundle\Entity\Notification;
-use Yokai\MessengerBundle\Tests\Fixtures\Recipient\DoctrineRecipient;
-use Yokai\MessengerBundle\Tests\Fixtures\Recipient\MobileRecipient;
-use Yokai\MessengerBundle\Tests\Fixtures\Recipient\SwiftmailerRecipient;
-use Yokai\MessengerBundle\Tests\Fixtures\Recipient\TwilioRecipient;
+use Yokai\MessengerBundle\Tests\Fixtures\Recipient\IdentifierRecipient;
+use Yokai\MessengerBundle\Tests\Fixtures\Recipient\NotificationRecipient;
+use Yokai\MessengerBundle\Tests\Fixtures\Recipient\EmailRecipient;
+use Yokai\MessengerBundle\Tests\Fixtures\Recipient\PhoneRecipient;
 
 /**
  * @author Yann Eugoné <eugone.yann@gmail.com>
@@ -64,13 +64,13 @@ class DoctrineChannelTest extends \PHPUnit_Framework_TestCase
 
     public function testIsCreatingNotificationEntity()
     {
-        $recipient = new DoctrineRecipient('1');
+        $recipient = new IdentifierRecipient('1');
 
         $notificationProphecy = Argument::allOf(
             Argument::type(Notification::class),
             Argument::which('getSubject', 'subject'),
             Argument::which('getBody', 'body'),
-            Argument::which('getRecipientClass', DoctrineRecipient::class),
+            Argument::which('getRecipientClass', IdentifierRecipient::class),
             Argument::which('getRecipientId', '1')
         );
 
@@ -104,19 +104,19 @@ class DoctrineChannelTest extends \PHPUnit_Framework_TestCase
     {
         return [
             [
-                new SwiftmailerRecipient('john.doe@acme.org'),
+                new EmailRecipient('john.doe@acme.org'),
                 false,
             ],
             [
-                new TwilioRecipient('+330601020304'),
+                new PhoneRecipient('+330601020304'),
                 false,
             ],
             [
-                new DoctrineRecipient('1'),
+                new IdentifierRecipient('1'),
                 true,
             ],
             [
-                new MobileRecipient(['foo', 'bar']),
+                new NotificationRecipient(['foo', 'bar']),
                 false,
             ],
         ];

--- a/Tests/Channel/MobileChannelTest.php
+++ b/Tests/Channel/MobileChannelTest.php
@@ -13,10 +13,10 @@ use Sly\NotificationPusher\PushManager;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Yokai\MessengerBundle\Channel\MobileChannel;
 use Yokai\MessengerBundle\Delivery;
-use Yokai\MessengerBundle\Tests\Fixtures\Recipient\DoctrineRecipient;
-use Yokai\MessengerBundle\Tests\Fixtures\Recipient\MobileRecipient;
-use Yokai\MessengerBundle\Tests\Fixtures\Recipient\SwiftmailerRecipient;
-use Yokai\MessengerBundle\Tests\Fixtures\Recipient\TwilioRecipient;
+use Yokai\MessengerBundle\Tests\Fixtures\Recipient\IdentifierRecipient;
+use Yokai\MessengerBundle\Tests\Fixtures\Recipient\NotificationRecipient;
+use Yokai\MessengerBundle\Tests\Fixtures\Recipient\EmailRecipient;
+use Yokai\MessengerBundle\Tests\Fixtures\Recipient\PhoneRecipient;
 
 /**
  * @author Yann Eugoné <eugone.yann@gmail.com>
@@ -71,7 +71,7 @@ class MobileChannelTest extends \PHPUnit_Framework_TestCase
 
     public function testIsPushingToPushManager()
     {
-        $recipient = new MobileRecipient(['foo', 'bar']);
+        $recipient = new NotificationRecipient(['foo', 'bar']);
 
         $fooAdapter = $this->createAdapter();
         $fooAdapter->supports('foo')
@@ -163,19 +163,19 @@ class MobileChannelTest extends \PHPUnit_Framework_TestCase
     {
         return [
             [
-                new SwiftmailerRecipient('john.doe@acme.org'),
+                new EmailRecipient('john.doe@acme.org'),
                 false,
             ],
             [
-                new TwilioRecipient('+330601020304'),
+                new PhoneRecipient('+330601020304'),
                 false,
             ],
             [
-                new DoctrineRecipient('1'),
+                new IdentifierRecipient('1'),
                 false,
             ],
             [
-                new MobileRecipient(['foo', 'bar']),
+                new NotificationRecipient(['foo', 'bar']),
                 true,
             ],
         ];

--- a/Tests/Channel/SwiftmailerChannelTest.php
+++ b/Tests/Channel/SwiftmailerChannelTest.php
@@ -8,10 +8,10 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 use Yokai\MessengerBundle\Channel\Swiftmailer\Configurator\SwiftMessageConfiguratorInterface;
 use Yokai\MessengerBundle\Channel\SwiftmailerChannel;
 use Yokai\MessengerBundle\Delivery;
-use Yokai\MessengerBundle\Tests\Fixtures\Recipient\DoctrineRecipient;
-use Yokai\MessengerBundle\Tests\Fixtures\Recipient\MobileRecipient;
-use Yokai\MessengerBundle\Tests\Fixtures\Recipient\SwiftmailerRecipient;
-use Yokai\MessengerBundle\Tests\Fixtures\Recipient\TwilioRecipient;
+use Yokai\MessengerBundle\Tests\Fixtures\Recipient\IdentifierRecipient;
+use Yokai\MessengerBundle\Tests\Fixtures\Recipient\NotificationRecipient;
+use Yokai\MessengerBundle\Tests\Fixtures\Recipient\EmailRecipient;
+use Yokai\MessengerBundle\Tests\Fixtures\Recipient\PhoneRecipient;
 
 /**
  * @author Yann Eugoné <eugone.yann@gmail.com>
@@ -82,7 +82,7 @@ class SwiftmailerChannelTest extends \PHPUnit_Framework_TestCase
     {
         $delivery1 = new Delivery(
             'test',
-            new SwiftmailerRecipient('john.doe@test.test'),
+            new EmailRecipient('john.doe@test.test'),
             [
                 'from' => 'no-reply@test.test'
             ],
@@ -151,7 +151,7 @@ class SwiftmailerChannelTest extends \PHPUnit_Framework_TestCase
     {
         $delivery1 = new Delivery(
             'test',
-            new SwiftmailerRecipient('john.doe@test.test'),
+            new EmailRecipient('john.doe@test.test'),
             [
                 'from' => [
                     'no-reply@test.test' => 'NoReply'
@@ -242,15 +242,15 @@ class SwiftmailerChannelTest extends \PHPUnit_Framework_TestCase
     {
         return [
             [
-                new DoctrineRecipient('1'),
+                new IdentifierRecipient('1'),
                 false,
             ],
             [
-                new SwiftmailerRecipient('john.doe@acme.org'),
+                new EmailRecipient('john.doe@acme.org'),
                 true,
             ],
             [
-                new TwilioRecipient('+330601020304'),
+                new PhoneRecipient('+330601020304'),
                 false,
             ],
             [
@@ -262,7 +262,7 @@ class SwiftmailerChannelTest extends \PHPUnit_Framework_TestCase
                 true,
             ],
             [
-                new MobileRecipient(['foo', 'bar']),
+                new NotificationRecipient(['foo', 'bar']),
                 false,
             ],
         ];

--- a/Tests/Channel/TwilioChannelTest.php
+++ b/Tests/Channel/TwilioChannelTest.php
@@ -7,10 +7,10 @@ use Yokai\MessengerBundle\Channel\Twilio\Factory\ClientFactoryInterface;
 use Yokai\MessengerBundle\Channel\TwilioChannel;
 use Yokai\MessengerBundle\Delivery;
 use Yokai\MessengerBundle\Tests\Channel\Mock\Twilio\Factory\MockClientFactory;
-use Yokai\MessengerBundle\Tests\Fixtures\Recipient\DoctrineRecipient;
-use Yokai\MessengerBundle\Tests\Fixtures\Recipient\MobileRecipient;
-use Yokai\MessengerBundle\Tests\Fixtures\Recipient\SwiftmailerRecipient;
-use Yokai\MessengerBundle\Tests\Fixtures\Recipient\TwilioRecipient;
+use Yokai\MessengerBundle\Tests\Fixtures\Recipient\IdentifierRecipient;
+use Yokai\MessengerBundle\Tests\Fixtures\Recipient\NotificationRecipient;
+use Yokai\MessengerBundle\Tests\Fixtures\Recipient\EmailRecipient;
+use Yokai\MessengerBundle\Tests\Fixtures\Recipient\PhoneRecipient;
 
 /**
  * @author Matthieu Crinquand <matthieu.crinquand@gmail.com>
@@ -171,7 +171,7 @@ class TwilioChannelTest extends \PHPUnit_Framework_TestCase
             ],
             [
                 '+15005550006',
-                new TwilioRecipient('+15005551234'),
+                new PhoneRecipient('+15005551234'),
                 false,
             ],
         ];
@@ -181,15 +181,15 @@ class TwilioChannelTest extends \PHPUnit_Framework_TestCase
     {
         return [
             [
-                new DoctrineRecipient('1'),
+                new IdentifierRecipient('1'),
                 false,
             ],
             [
-                new SwiftmailerRecipient('john.doe@acme.org'),
+                new EmailRecipient('john.doe@acme.org'),
                 false,
             ],
             [
-                new TwilioRecipient('+330601020304'),
+                new PhoneRecipient('+330601020304'),
                 true,
             ],
             [
@@ -197,7 +197,7 @@ class TwilioChannelTest extends \PHPUnit_Framework_TestCase
                 true,
             ],
             [
-                new MobileRecipient(['foo', 'bar']),
+                new NotificationRecipient(['foo', 'bar']),
                 false,
             ],
         ];

--- a/Tests/Entity/NotificationTest.php
+++ b/Tests/Entity/NotificationTest.php
@@ -3,7 +3,7 @@
 namespace Yokai\MessengerBundle\Tests\Entity;
 
 use Yokai\MessengerBundle\Entity\Notification;
-use Yokai\MessengerBundle\Tests\Fixtures\Recipient\DoctrineRecipient;
+use Yokai\MessengerBundle\Tests\Fixtures\Recipient\IdentifierRecipient;
 
 /**
  * @author Yann Eugoné <eugone.yann@gmail.com>
@@ -15,13 +15,13 @@ class NotificationTest extends \PHPUnit_Framework_TestCase
         $notification = new Notification(
             'subject',
             'body',
-            new DoctrineRecipient('1')
+            new IdentifierRecipient('1')
         );
 
         $this->assertSame(null, $notification->getId());
         $this->assertSame('subject', $notification->getSubject());
         $this->assertSame('body', $notification->getBody());
-        $this->assertSame(DoctrineRecipient::class, $notification->getRecipientClass());
+        $this->assertSame(IdentifierRecipient::class, $notification->getRecipientClass());
         $this->assertSame('1', $notification->getRecipientId());
         $this->assertInstanceOf(\DateTime::class, $notification->getRecordedAt());
 
@@ -37,7 +37,7 @@ class NotificationTest extends \PHPUnit_Framework_TestCase
         $notification = new Notification(
             'subject',
             'body',
-            new DoctrineRecipient('1')
+            new IdentifierRecipient('1')
         );
 
         $notification->setDelivered();

--- a/Tests/Fixtures/Recipient/EmailRecipient.php
+++ b/Tests/Fixtures/Recipient/EmailRecipient.php
@@ -2,12 +2,12 @@
 
 namespace Yokai\MessengerBundle\Tests\Fixtures\Recipient;
 
-use Yokai\MessengerBundle\Recipient\SwiftmailerRecipientInterface;
+use Yokai\MessengerBundle\Recipient\EmailRecipientInterface;
 
 /**
  * @author Yann Eugoné <eugone.yann@gmail.com>
  */
-class SwiftmailerRecipient implements SwiftmailerRecipientInterface
+class EmailRecipient implements EmailRecipientInterface
 {
     private $email;
 

--- a/Tests/Fixtures/Recipient/IdentifierRecipient.php
+++ b/Tests/Fixtures/Recipient/IdentifierRecipient.php
@@ -2,12 +2,12 @@
 
 namespace Yokai\MessengerBundle\Tests\Fixtures\Recipient;
 
-use Yokai\MessengerBundle\Recipient\DoctrineRecipientInterface;
+use Yokai\MessengerBundle\Recipient\IdentifierRecipientInterface;
 
 /**
  * @author Yann Eugoné <eugone.yann@gmail.com>
  */
-class DoctrineRecipient implements DoctrineRecipientInterface
+class IdentifierRecipient implements IdentifierRecipientInterface
 {
     private $id;
 

--- a/Tests/Fixtures/Recipient/NotificationRecipient.php
+++ b/Tests/Fixtures/Recipient/NotificationRecipient.php
@@ -2,12 +2,12 @@
 
 namespace Yokai\MessengerBundle\Tests\Fixtures\Recipient;
 
-use Yokai\MessengerBundle\Recipient\MobileRecipientInterface;
+use Yokai\MessengerBundle\Recipient\NotificationRecipientInterface;
 
 /**
  * @author Yann Eugoné <eugone.yann@gmail.com>
  */
-class MobileRecipient implements MobileRecipientInterface
+class NotificationRecipient implements NotificationRecipientInterface
 {
     /**
      * @var array

--- a/Tests/Fixtures/Recipient/PhoneRecipient.php
+++ b/Tests/Fixtures/Recipient/PhoneRecipient.php
@@ -2,12 +2,12 @@
 
 namespace Yokai\MessengerBundle\Tests\Fixtures\Recipient;
 
-use Yokai\MessengerBundle\Recipient\TwilioRecipientInterface;
+use Yokai\MessengerBundle\Recipient\PhoneRecipientInterface;
 
 /**
  * @author Matthieu Crinquand <matthieu.crinquand@gmail.com>
  */
-class TwilioRecipient implements TwilioRecipientInterface
+class PhoneRecipient implements PhoneRecipientInterface
 {
     private $phone;
 


### PR DESCRIPTION
Following suggestions of #34 all recipient interfaces are renamed to be less coupled to the channel using it.

Other interfaces was flagged as deprecated prior to `1.5` : 

- `DoctrineRecipientInterface` -> `IdentifierRecipientInterface`
- `MobileRecipientInterface` -> `NotificationRecipientInterface`
- `SwiftmailerRecipientInterface` -> `EmailRecipientInterface`
- `TwilioRecipientInterface` -> `PhoneRecipientInterface`
