### PR TITLE
Allow not building subject nor body

### DIFF
--- a/Helper/ContentBuilder.php
+++ b/Helper/ContentBuilder.php
@@ -51,18 +51,29 @@ class ContentBuilder
     public function configure($options)
     {
         $resolver = (new OptionsResolver)
-            ->setRequired(['template'])
+            ->setDefault('template', '')
+            ->setAllowedTypes('template', ['string', 'null', 'boolean'])
+
             ->setDefault('subject', '')
+            ->setAllowedTypes('subject', ['string', 'null', 'boolean'])
+
             ->setDefault('translation_catalog', '')
+            ->setAllowedTypes('translation_catalog', 'string')
+
             ->setDefault('subject_parameters', [])
-            ->setDefault('template_parameters', [])
-            ->setDefault('template_vars', [])
+            ->setAllowedTypes('subject_parameters', 'array')
             ->setNormalizer('subject_parameters', function ($opts, $value) {
                 return array_values((array) $value);
             })
+
+            ->setDefault('template_parameters', [])
+            ->setAllowedTypes('template_parameters', 'array')
             ->setNormalizer('template_parameters', function ($opts, $value) {
                 return array_values((array) $value);
             })
+
+            ->setDefault('template_vars', [])
+            ->setAllowedTypes('template_vars', 'array')
             ->setNormalizer('template_vars', function ($opts, $value) {
                 return (array) $value;
             })
@@ -96,6 +107,10 @@ class ContentBuilder
             );
         }
 
+        if (!$this->options['subject']) {
+            return '';
+        }
+
         return $this->translator->trans(
             $this->options['subject'],
             array_intersect_key($parameters, array_flip($this->options['subject_parameters'])),
@@ -115,6 +130,10 @@ class ContentBuilder
                 __CLASS__.'::configure',
                 __METHOD__
             );
+        }
+
+        if (!$this->options['template']) {
+            return '';
         }
 
         return $this->templating->render(

--- a/Tests/Helper/ContentBuilderTest.php
+++ b/Tests/Helper/ContentBuilderTest.php
@@ -142,7 +142,7 @@ class ContentBuilderTest extends \PHPUnit_Framework_TestCase
 
         $helper->configure(['subject' => $value, 'template' => $value]);
 
-        $this->templating->render(Argument::cetera())
+        $this->twig->render(Argument::cetera())
             ->shouldNotBeCalled();
         $this->translator->trans(Argument::cetera())
             ->shouldNotBeCalled();

--- a/Tests/Helper/ContentBuilderTest.php
+++ b/Tests/Helper/ContentBuilderTest.php
@@ -2,6 +2,7 @@
 
 namespace Yokai\MessengerBundle\Tests\Helper;
 
+use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Component\Templating\EngineInterface;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -131,6 +132,24 @@ class ContentBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('test ok', $helper->getBody($parameters));
     }
 
+    /**
+     * @dataProvider noBuild
+     */
+    public function testBuildNoSubject($value)
+    {
+        $helper = $this->createHelper([]);
+
+        $helper->configure(['subject' => $value, 'template' => $value]);
+
+        $this->templating->render(Argument::cetera())
+            ->shouldNotBeCalled();
+        $this->translator->trans(Argument::cetera())
+            ->shouldNotBeCalled();
+
+        $this->assertSame('', $helper->getSubject([]));
+        $this->assertSame('', $helper->getBody([]));
+    }
+
     public function subjectProvider()
     {
         return [
@@ -223,6 +242,15 @@ class ContentBuilderTest extends \PHPUnit_Framework_TestCase
                     '{greet}' => 'name',
                 ],
             ],
+        ];
+    }
+
+    public function noBuild()
+    {
+        return [
+            [null],
+            [''],
+            [false],
         ];
     }
 }


### PR DESCRIPTION
Following #36 we noticed that building subject and body were required thing.

Although some channel are not requiring subject nor body.

We just allowed `subject` & `template` options to be falsy.

If each of this option provided as falsy, we don't try to build the corresponding value.